### PR TITLE
Copy type_description_interfaces structs to runtime_c/cpp

### DIFF
--- a/rosidl_runtime_c/CMakeLists.txt
+++ b/rosidl_runtime_c/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosidl_typesupport_interface REQUIRED)
 
+file(GLOB type_description_sources "src/type_description/*.c")
+file(GLOB type_description_includes "include/rosidl_runtime_c/type_description/*.h")
 add_library(${PROJECT_NAME}
   "src/message_type_support.c"
   "src/primitives_sequence_functions.c"
@@ -23,6 +25,7 @@ add_library(${PROJECT_NAME}
   "src/string_functions.c"
   "src/type_hash.c"
   "src/u16string_functions.c"
+  ${type_description_sources}
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -60,7 +63,30 @@ if(BUILD_TESTING)
   # Give cppcheck hints about macro definitions coming from outside this package
   get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS performance_test_fixture::performance_test_fixture
     INTERFACE_INCLUDE_DIRECTORIES)
+
+  set(AMENT_LINT_AUTO_FILE_EXCLUDE ${type_description_includes} ${type_description_sources})
   ament_lint_auto_find_test_dependencies()
+
+  # Run specific linters on copied generated code
+  if(ament_cmake_cppcheck_FOUND)
+    ament_cppcheck(
+      TESTNAME "cppcheck_copied_type_description_interfaces"
+      ${type_description_includes} ${type_description_sources})
+  endif()
+  if(ament_cmake_cpplint_FOUND)
+    ament_cpplint(
+      TESTNAME "cpplint_copied_type_description_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ${type_description_includes} ${type_description_sources})
+  endif()
+  if(ament_cmake_uncrustify_FOUND)
+    ament_uncrustify(
+      TESTNAME "uncrustify_copied_type_description_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 0
+      ${type_description_includes} ${type_description_sources})
+  endif()
 
   # For gtest
   enable_language(CXX)

--- a/rosidl_runtime_c/docs/FEATURES.md
+++ b/rosidl_runtime_c/docs/FEATURES.md
@@ -27,3 +27,16 @@ They are defined for the three main ROS 2 rosidl types:
 * Messages (`message_type_support_struct.h`)
 * Services (`service_type_support_struct.h`)
 * Actions (`action_type_support_struct.h`)
+
+## Type Description Interface Structs
+
+A copy of the output of `rosidl_generator_c` for `type_description_interfaces` messages.
+
+Provides base runtime representations of the descriptions of interface types in C.
+These can be used in code generation to embed descriptions of types, and can be used for programmatic creation of dynamic types.
+The types are renamed so that they do not overlap with `type_description_interfaces` - and can be used in their code generation so that even those messages are self-describing.
+
+Note that end users will typically fetch and use the `type_description_interfaces__msg__TypeDescription` and its members instead of the `rosidl_runtime_c` types.
+Functions will be provided in `rcl` that convert between `rosidl_runtime_c__type_description__` and `type_description_interfaces__msg__` types.
+
+See `rosidl/scripts/copy_type_descripiton_generated_sources.bash` for usage and details of how sources are copied, and what modifications are made.

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field__functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field__functions.h
@@ -1,0 +1,177 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD__FUNCTIONS_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_runtime_c/type_description/field__struct.h"
+
+/// Initialize msg/Field message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * rosidl_runtime_c__type_description__Field
+ * )) before or use
+ * rosidl_runtime_c__type_description__Field__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__Field__init(rosidl_runtime_c__type_description__Field * msg);
+
+/// Finalize msg/Field message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__Field__fini(rosidl_runtime_c__type_description__Field * msg);
+
+/// Create msg/Field message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * rosidl_runtime_c__type_description__Field__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__Field *
+rosidl_runtime_c__type_description__Field__create();
+
+/// Destroy msg/Field message.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__Field__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__Field__destroy(rosidl_runtime_c__type_description__Field * msg);
+
+/// Check for msg/Field message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__Field__are_equal(const rosidl_runtime_c__type_description__Field * lhs, const rosidl_runtime_c__type_description__Field * rhs);
+
+/// Copy a msg/Field message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__Field__copy(
+  const rosidl_runtime_c__type_description__Field * input,
+  rosidl_runtime_c__type_description__Field * output);
+
+/// Initialize array of msg/Field messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * rosidl_runtime_c__type_description__Field__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__Field__Sequence__init(rosidl_runtime_c__type_description__Field__Sequence * array, size_t size);
+
+/// Finalize array of msg/Field messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__Field__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__Field__Sequence__fini(rosidl_runtime_c__type_description__Field__Sequence * array);
+
+/// Create array of msg/Field messages.
+/**
+ * It allocates the memory for the array and calls
+ * rosidl_runtime_c__type_description__Field__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__Field__Sequence *
+rosidl_runtime_c__type_description__Field__Sequence__create(size_t size);
+
+/// Destroy array of msg/Field messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__Field__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__Field__Sequence__destroy(rosidl_runtime_c__type_description__Field__Sequence * array);
+
+/// Check for msg/Field message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__Field__Sequence__are_equal(const rosidl_runtime_c__type_description__Field__Sequence * lhs, const rosidl_runtime_c__type_description__Field__Sequence * rhs);
+
+/// Copy an array of msg/Field messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__Field__Sequence__copy(
+  const rosidl_runtime_c__type_description__Field__Sequence * input,
+  rosidl_runtime_c__type_description__Field__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD__FUNCTIONS_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field__struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field__struct.h
@@ -1,0 +1,67 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD__STRUCT_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/type_hash.h"
+
+
+// Type Hash for interface
+static const rosidl_type_hash_t rosidl_runtime_c__type_description__Field__TYPE_HASH = {1, {
+    0xc0, 0xb0, 0x13, 0x79, 0xcd, 0x42, 0x26, 0x28,
+    0x12, 0x85, 0xcc, 0xaf, 0x6b, 0xe4, 0x66, 0x53,
+    0x96, 0x8f, 0x85, 0x5f, 0x7c, 0x5e, 0x41, 0x61,
+    0x4f, 0xf5, 0xd7, 0xa8, 0x54, 0xef, 0xef, 0x7c,
+  }};
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'name'
+// Member 'default_value'
+#include "rosidl_runtime_c/string.h"
+// Member 'type'
+#include "rosidl_runtime_c/type_description/field_type__struct.h"
+
+/// Struct defined in msg/Field in the package type_description_interfaces.
+/**
+  * Represents a single field in a type.
+ */
+typedef struct rosidl_runtime_c__type_description__Field
+{
+  /// Name of the field.
+  rosidl_runtime_c__String name;
+  /// Type of the field, including details about the type like length, nested name, etc.
+  rosidl_runtime_c__type_description__FieldType type;
+  /// Literal default value of the field as a string, as it appeared in the original
+  /// message description file, whether that be .msg/.srv/.action or .idl.
+  rosidl_runtime_c__String default_value;
+} rosidl_runtime_c__type_description__Field;
+
+// Struct for a sequence of rosidl_runtime_c__type_description__Field.
+typedef struct rosidl_runtime_c__type_description__Field__Sequence
+{
+  rosidl_runtime_c__type_description__Field * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_runtime_c__type_description__Field__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD__STRUCT_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field_type__functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field_type__functions.h
@@ -1,0 +1,177 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD_TYPE__FUNCTIONS_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD_TYPE__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_runtime_c/type_description/field_type__struct.h"
+
+/// Initialize msg/FieldType message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * rosidl_runtime_c__type_description__FieldType
+ * )) before or use
+ * rosidl_runtime_c__type_description__FieldType__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__FieldType__init(rosidl_runtime_c__type_description__FieldType * msg);
+
+/// Finalize msg/FieldType message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__FieldType__fini(rosidl_runtime_c__type_description__FieldType * msg);
+
+/// Create msg/FieldType message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * rosidl_runtime_c__type_description__FieldType__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__FieldType *
+rosidl_runtime_c__type_description__FieldType__create();
+
+/// Destroy msg/FieldType message.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__FieldType__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__FieldType__destroy(rosidl_runtime_c__type_description__FieldType * msg);
+
+/// Check for msg/FieldType message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__FieldType__are_equal(const rosidl_runtime_c__type_description__FieldType * lhs, const rosidl_runtime_c__type_description__FieldType * rhs);
+
+/// Copy a msg/FieldType message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__FieldType__copy(
+  const rosidl_runtime_c__type_description__FieldType * input,
+  rosidl_runtime_c__type_description__FieldType * output);
+
+/// Initialize array of msg/FieldType messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * rosidl_runtime_c__type_description__FieldType__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__FieldType__Sequence__init(rosidl_runtime_c__type_description__FieldType__Sequence * array, size_t size);
+
+/// Finalize array of msg/FieldType messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__FieldType__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__FieldType__Sequence__fini(rosidl_runtime_c__type_description__FieldType__Sequence * array);
+
+/// Create array of msg/FieldType messages.
+/**
+ * It allocates the memory for the array and calls
+ * rosidl_runtime_c__type_description__FieldType__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__FieldType__Sequence *
+rosidl_runtime_c__type_description__FieldType__Sequence__create(size_t size);
+
+/// Destroy array of msg/FieldType messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__FieldType__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__FieldType__Sequence__destroy(rosidl_runtime_c__type_description__FieldType__Sequence * array);
+
+/// Check for msg/FieldType message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__FieldType__Sequence__are_equal(const rosidl_runtime_c__type_description__FieldType__Sequence * lhs, const rosidl_runtime_c__type_description__FieldType__Sequence * rhs);
+
+/// Copy an array of msg/FieldType messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__FieldType__Sequence__copy(
+  const rosidl_runtime_c__type_description__FieldType__Sequence * input,
+  rosidl_runtime_c__type_description__FieldType__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD_TYPE__FUNCTIONS_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field_type__struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/field_type__struct.h
@@ -1,0 +1,671 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD_TYPE__STRUCT_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD_TYPE__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/type_hash.h"
+
+
+// Type Hash for interface
+static const rosidl_type_hash_t rosidl_runtime_c__type_description__FieldType__TYPE_HASH = {1, {
+    0xa7, 0x0b, 0x6d, 0xd9, 0x19, 0x64, 0x5a, 0x03,
+    0xa3, 0x58, 0x6f, 0x7f, 0x82, 0x1d, 0xef, 0xbc,
+    0x88, 0x6e, 0xa3, 0xe5, 0x31, 0xa1, 0xd9, 0x5c,
+    0xc0, 0xf3, 0x80, 0xa3, 0x97, 0x3c, 0xca, 0xa6,
+  }};
+
+// Constants defined in the message
+
+/// Constant 'FIELD_TYPE_NOT_SET'.
+/**
+  * A constant for each type supported according to:
+  *   http://design.ros2.org/articles/legacy_interface_definition.html
+  * and:
+  *   http://design.ros2.org/articles/idl_interface_definition.html
+  * Order is loosely coupled to the order of appearance in the IDL 4.2 spec:
+  *  https://www.omg.org/spec/IDL/4.2
+  * Layout of constants across the 0-255 decimal values in the uint8:
+  *
+  * - 000    : Reserved for "not set"
+  * - 001-048: Primitive types, strings, and reserved space for future primitive types
+  * - 049-096: Fixed sized array of primitive and string types
+  * - 097-144: Bounded Sequences of primitive and string types
+  * - 145-192: Unbounded Sequences of primitive and string types
+  * - 193-255: Reserved space for future array/sequence-like types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_NOT_SET = 0
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE'.
+/**
+  * Nested type defined in other .msg/.idl files.
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_NESTED_TYPE = 1
+};
+
+/// Constant 'FIELD_TYPE_INT8'.
+/**
+  * Integer Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT8 = 2
+};
+
+/// Constant 'FIELD_TYPE_UINT8'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT8 = 3
+};
+
+/// Constant 'FIELD_TYPE_INT16'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT16 = 4
+};
+
+/// Constant 'FIELD_TYPE_UINT16'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT16 = 5
+};
+
+/// Constant 'FIELD_TYPE_INT32'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT32 = 6
+};
+
+/// Constant 'FIELD_TYPE_UINT32'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT32 = 7
+};
+
+/// Constant 'FIELD_TYPE_INT64'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT64 = 8
+};
+
+/// Constant 'FIELD_TYPE_UINT64'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT64 = 9
+};
+
+/// Constant 'FIELD_TYPE_FLOAT'.
+/**
+  * Floating-Point Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FLOAT = 10
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_DOUBLE = 11
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_LONG_DOUBLE = 12
+};
+
+/// Constant 'FIELD_TYPE_CHAR'.
+/**
+  * Char and WChar Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_CHAR = 13
+};
+
+/// Constant 'FIELD_TYPE_WCHAR'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WCHAR = 14
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN'.
+/**
+  * Boolean Type
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOOLEAN = 15
+};
+
+/// Constant 'FIELD_TYPE_BYTE'.
+/**
+  * Byte/Octet Type
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BYTE = 16
+};
+
+/// Constant 'FIELD_TYPE_STRING'.
+/**
+  * String Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_STRING = 17
+};
+
+/// Constant 'FIELD_TYPE_WSTRING'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WSTRING = 18
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING'.
+/**
+  * Fixed String Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_STRING = 19
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_WSTRING = 20
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING'.
+/**
+  * Bounded String Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_STRING = 21
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_WSTRING = 22
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE_ARRAY'.
+/**
+  * Fixed Sized Array Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_NESTED_TYPE_ARRAY = 49
+};
+
+/// Constant 'FIELD_TYPE_INT8_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT8_ARRAY = 50
+};
+
+/// Constant 'FIELD_TYPE_UINT8_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT8_ARRAY = 51
+};
+
+/// Constant 'FIELD_TYPE_INT16_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT16_ARRAY = 52
+};
+
+/// Constant 'FIELD_TYPE_UINT16_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT16_ARRAY = 53
+};
+
+/// Constant 'FIELD_TYPE_INT32_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT32_ARRAY = 54
+};
+
+/// Constant 'FIELD_TYPE_UINT32_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT32_ARRAY = 55
+};
+
+/// Constant 'FIELD_TYPE_INT64_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT64_ARRAY = 56
+};
+
+/// Constant 'FIELD_TYPE_UINT64_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT64_ARRAY = 57
+};
+
+/// Constant 'FIELD_TYPE_FLOAT_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FLOAT_ARRAY = 58
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_DOUBLE_ARRAY = 59
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_LONG_DOUBLE_ARRAY = 60
+};
+
+/// Constant 'FIELD_TYPE_CHAR_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_CHAR_ARRAY = 61
+};
+
+/// Constant 'FIELD_TYPE_WCHAR_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WCHAR_ARRAY = 62
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOOLEAN_ARRAY = 63
+};
+
+/// Constant 'FIELD_TYPE_BYTE_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BYTE_ARRAY = 64
+};
+
+/// Constant 'FIELD_TYPE_STRING_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_STRING_ARRAY = 65
+};
+
+/// Constant 'FIELD_TYPE_WSTRING_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WSTRING_ARRAY = 66
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_STRING_ARRAY = 67
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_WSTRING_ARRAY = 68
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_STRING_ARRAY = 69
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING_ARRAY'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_WSTRING_ARRAY = 70
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE'.
+/**
+  * Bounded Sequence Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE = 97
+};
+
+/// Constant 'FIELD_TYPE_INT8_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT8_BOUNDED_SEQUENCE = 98
+};
+
+/// Constant 'FIELD_TYPE_UINT8_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT8_BOUNDED_SEQUENCE = 99
+};
+
+/// Constant 'FIELD_TYPE_INT16_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT16_BOUNDED_SEQUENCE = 100
+};
+
+/// Constant 'FIELD_TYPE_UINT16_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT16_BOUNDED_SEQUENCE = 101
+};
+
+/// Constant 'FIELD_TYPE_INT32_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT32_BOUNDED_SEQUENCE = 102
+};
+
+/// Constant 'FIELD_TYPE_UINT32_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT32_BOUNDED_SEQUENCE = 103
+};
+
+/// Constant 'FIELD_TYPE_INT64_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT64_BOUNDED_SEQUENCE = 104
+};
+
+/// Constant 'FIELD_TYPE_UINT64_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT64_BOUNDED_SEQUENCE = 105
+};
+
+/// Constant 'FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE = 106
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE = 107
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE = 108
+};
+
+/// Constant 'FIELD_TYPE_CHAR_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_CHAR_BOUNDED_SEQUENCE = 109
+};
+
+/// Constant 'FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE = 110
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE = 111
+};
+
+/// Constant 'FIELD_TYPE_BYTE_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BYTE_BOUNDED_SEQUENCE = 112
+};
+
+/// Constant 'FIELD_TYPE_STRING_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_STRING_BOUNDED_SEQUENCE = 113
+};
+
+/// Constant 'FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE = 114
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE = 115
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE = 116
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE = 117
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE = 118
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE'.
+/**
+  * Unbounded Sequence Types
+ */
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE = 145
+};
+
+/// Constant 'FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE = 146
+};
+
+/// Constant 'FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE = 147
+};
+
+/// Constant 'FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE = 148
+};
+
+/// Constant 'FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE = 149
+};
+
+/// Constant 'FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE = 150
+};
+
+/// Constant 'FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE = 151
+};
+
+/// Constant 'FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE = 152
+};
+
+/// Constant 'FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE = 153
+};
+
+/// Constant 'FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE = 154
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE = 155
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE = 156
+};
+
+/// Constant 'FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE = 157
+};
+
+/// Constant 'FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE = 158
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE = 159
+};
+
+/// Constant 'FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE = 160
+};
+
+/// Constant 'FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE = 161
+};
+
+/// Constant 'FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE = 162
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE = 163
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE = 164
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE = 165
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE = 166
+};
+
+// Include directives for member types
+// Member 'nested_type_name'
+#include "rosidl_runtime_c/string.h"
+
+// constants for array fields with an upper bound
+// nested_type_name
+enum
+{
+  rosidl_runtime_c__type_description__FieldType__nested_type_name__MAX_STRING_SIZE = 255
+};
+
+/// Struct defined in msg/FieldType in the package type_description_interfaces.
+/**
+  * Represents the type of a field and related meta-data.
+ */
+typedef struct rosidl_runtime_c__type_description__FieldType
+{
+  /// Identifying number for the type of the field, using one of the above constants.
+  uint8_t type_id;
+  /// Only used when the type is an array or a bounded sequence.
+  /// In the case of an array, this is the fixed capacity of the array.
+  /// In the case of a bounded sequence, this is the maximum capacity of the sequence.
+  /// In all other cases this field is unused.
+  uint64_t capacity;
+  /// Only used when the type is a fixed or bounded string/wstring, or a array/sequence of those.
+  /// In the case of a fixed string/wstring, it is the fixed length of the string.
+  /// In the case of a bounded string/wstring, it is the maximum capacity of the string.
+  /// In the case of an array/sequence of fixed string/wstring, it is the fixed length of the strings.
+  /// In the case of an array/sequence of bounded string/wstring, it is the maximum capacity of the strings.
+  /// It is not currently possible to have different string capacities per element in the array/sequence.
+  uint64_t string_capacity;
+  /// Only used when the type is a nested type or array/sequence of nested types.
+  /// This is limited to 255 characters.
+  /// TODO(wjwwood): this 255 character limit was chosen due to this being the limit
+  ///   for DDSI-RTPS based middlewares, which is the most commonly used right now.
+  ///   We lack a ROS 2 specific limit in our design documents, but we should update
+  ///   this and/or link to the design doc when that is available.
+  rosidl_runtime_c__String nested_type_name;
+} rosidl_runtime_c__type_description__FieldType;
+
+// Struct for a sequence of rosidl_runtime_c__type_description__FieldType.
+typedef struct rosidl_runtime_c__type_description__FieldType__Sequence
+{
+  rosidl_runtime_c__type_description__FieldType * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_runtime_c__type_description__FieldType__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__FIELD_TYPE__STRUCT_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/individual_type_description__functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/individual_type_description__functions.h
@@ -1,0 +1,177 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__FUNCTIONS_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_runtime_c/type_description/individual_type_description__struct.h"
+
+/// Initialize msg/IndividualTypeDescription message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * rosidl_runtime_c__type_description__IndividualTypeDescription
+ * )) before or use
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__init(rosidl_runtime_c__type_description__IndividualTypeDescription * msg);
+
+/// Finalize msg/IndividualTypeDescription message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__fini(rosidl_runtime_c__type_description__IndividualTypeDescription * msg);
+
+/// Create msg/IndividualTypeDescription message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__IndividualTypeDescription *
+rosidl_runtime_c__type_description__IndividualTypeDescription__create();
+
+/// Destroy msg/IndividualTypeDescription message.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__destroy(rosidl_runtime_c__type_description__IndividualTypeDescription * msg);
+
+/// Check for msg/IndividualTypeDescription message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__are_equal(const rosidl_runtime_c__type_description__IndividualTypeDescription * lhs, const rosidl_runtime_c__type_description__IndividualTypeDescription * rhs);
+
+/// Copy a msg/IndividualTypeDescription message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__copy(
+  const rosidl_runtime_c__type_description__IndividualTypeDescription * input,
+  rosidl_runtime_c__type_description__IndividualTypeDescription * output);
+
+/// Initialize array of msg/IndividualTypeDescription messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__init(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array, size_t size);
+
+/// Finalize array of msg/IndividualTypeDescription messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__fini(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array);
+
+/// Create array of msg/IndividualTypeDescription messages.
+/**
+ * It allocates the memory for the array and calls
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence *
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__create(size_t size);
+
+/// Destroy array of msg/IndividualTypeDescription messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__destroy(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array);
+
+/// Check for msg/IndividualTypeDescription message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__are_equal(const rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * lhs, const rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * rhs);
+
+/// Copy an array of msg/IndividualTypeDescription messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__copy(
+  const rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * input,
+  rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__FUNCTIONS_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/individual_type_description__struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/individual_type_description__struct.h
@@ -1,0 +1,75 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/type_hash.h"
+
+
+// Type Hash for interface
+static const rosidl_type_hash_t rosidl_runtime_c__type_description__IndividualTypeDescription__TYPE_HASH = {1, {
+    0x55, 0xc8, 0x27, 0xd8, 0x6c, 0x3c, 0x14, 0x1b,
+    0xdd, 0x31, 0x8f, 0xe6, 0xc2, 0x2e, 0x11, 0x19,
+    0x0e, 0x4d, 0x3b, 0x37, 0xc8, 0xf4, 0xf9, 0x75,
+    0x1a, 0x08, 0x4a, 0xa0, 0x5c, 0xe9, 0x65, 0x60,
+  }};
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'type_name'
+#include "rosidl_runtime_c/string.h"
+// Member 'fields'
+#include "rosidl_runtime_c/type_description/field__struct.h"
+
+// constants for array fields with an upper bound
+// type_name
+enum
+{
+  rosidl_runtime_c__type_description__IndividualTypeDescription__type_name__MAX_STRING_SIZE = 255
+};
+
+/// Struct defined in msg/IndividualTypeDescription in the package type_description_interfaces.
+/**
+  * Represents a single type, without the types it references, if any.
+ */
+typedef struct rosidl_runtime_c__type_description__IndividualTypeDescription
+{
+  /// Name of the type.
+  /// This is limited to 255 characters.
+  /// TODO(wjwwood): this 255 character limit was chosen due to this being the limit
+  ///   for DDSI-RTPS based middlewares, which is the most commonly used right now.
+  ///   We lack a ROS 2 specific limit in our design documents, but we should update
+  ///   this and/or link to the design doc when that is available.
+  rosidl_runtime_c__String type_name;
+  /// Fields of the type.
+  rosidl_runtime_c__type_description__Field__Sequence fields;
+} rosidl_runtime_c__type_description__IndividualTypeDescription;
+
+// Struct for a sequence of rosidl_runtime_c__type_description__IndividualTypeDescription.
+typedef struct rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence
+{
+  rosidl_runtime_c__type_description__IndividualTypeDescription * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/key_value__functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/key_value__functions.h
@@ -1,0 +1,177 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/KeyValue.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__KEY_VALUE__FUNCTIONS_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__KEY_VALUE__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_runtime_c/type_description/key_value__struct.h"
+
+/// Initialize msg/KeyValue message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * rosidl_runtime_c__type_description__KeyValue
+ * )) before or use
+ * rosidl_runtime_c__type_description__KeyValue__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__KeyValue__init(rosidl_runtime_c__type_description__KeyValue * msg);
+
+/// Finalize msg/KeyValue message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__KeyValue__fini(rosidl_runtime_c__type_description__KeyValue * msg);
+
+/// Create msg/KeyValue message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * rosidl_runtime_c__type_description__KeyValue__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__KeyValue *
+rosidl_runtime_c__type_description__KeyValue__create();
+
+/// Destroy msg/KeyValue message.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__KeyValue__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__KeyValue__destroy(rosidl_runtime_c__type_description__KeyValue * msg);
+
+/// Check for msg/KeyValue message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__KeyValue__are_equal(const rosidl_runtime_c__type_description__KeyValue * lhs, const rosidl_runtime_c__type_description__KeyValue * rhs);
+
+/// Copy a msg/KeyValue message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__KeyValue__copy(
+  const rosidl_runtime_c__type_description__KeyValue * input,
+  rosidl_runtime_c__type_description__KeyValue * output);
+
+/// Initialize array of msg/KeyValue messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * rosidl_runtime_c__type_description__KeyValue__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__KeyValue__Sequence__init(rosidl_runtime_c__type_description__KeyValue__Sequence * array, size_t size);
+
+/// Finalize array of msg/KeyValue messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__KeyValue__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__KeyValue__Sequence__fini(rosidl_runtime_c__type_description__KeyValue__Sequence * array);
+
+/// Create array of msg/KeyValue messages.
+/**
+ * It allocates the memory for the array and calls
+ * rosidl_runtime_c__type_description__KeyValue__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__KeyValue__Sequence *
+rosidl_runtime_c__type_description__KeyValue__Sequence__create(size_t size);
+
+/// Destroy array of msg/KeyValue messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__KeyValue__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__KeyValue__Sequence__destroy(rosidl_runtime_c__type_description__KeyValue__Sequence * array);
+
+/// Check for msg/KeyValue message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__KeyValue__Sequence__are_equal(const rosidl_runtime_c__type_description__KeyValue__Sequence * lhs, const rosidl_runtime_c__type_description__KeyValue__Sequence * rhs);
+
+/// Copy an array of msg/KeyValue messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__KeyValue__Sequence__copy(
+  const rosidl_runtime_c__type_description__KeyValue__Sequence * input,
+  rosidl_runtime_c__type_description__KeyValue__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__KEY_VALUE__FUNCTIONS_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/key_value__struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/key_value__struct.h
@@ -1,0 +1,60 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/KeyValue.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__KEY_VALUE__STRUCT_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__KEY_VALUE__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/type_hash.h"
+
+
+// Type Hash for interface
+static const rosidl_type_hash_t rosidl_runtime_c__type_description__KeyValue__TYPE_HASH = {1, {
+    0x27, 0x4f, 0xe5, 0x6b, 0xf1, 0x4f, 0x33, 0xc7,
+    0x51, 0x2e, 0x34, 0xc6, 0x46, 0xa3, 0x75, 0x79,
+    0xee, 0x36, 0x77, 0x9f, 0x74, 0x5f, 0x04, 0x9a,
+    0x97, 0x60, 0x76, 0x3e, 0x81, 0x7f, 0x0c, 0x42,
+  }};
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'key'
+// Member 'value'
+#include "rosidl_runtime_c/string.h"
+
+/// Struct defined in msg/KeyValue in the package type_description_interfaces.
+/**
+  * Represents an arbitrary key-value pair for application-specific information.
+ */
+typedef struct rosidl_runtime_c__type_description__KeyValue
+{
+  rosidl_runtime_c__String key;
+  rosidl_runtime_c__String value;
+} rosidl_runtime_c__type_description__KeyValue;
+
+// Struct for a sequence of rosidl_runtime_c__type_description__KeyValue.
+typedef struct rosidl_runtime_c__type_description__KeyValue__Sequence
+{
+  rosidl_runtime_c__type_description__KeyValue * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_runtime_c__type_description__KeyValue__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__KEY_VALUE__STRUCT_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_description__functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_description__functions.h
@@ -1,0 +1,177 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_DESCRIPTION__FUNCTIONS_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_DESCRIPTION__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_runtime_c/type_description/type_description__struct.h"
+
+/// Initialize msg/TypeDescription message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * rosidl_runtime_c__type_description__TypeDescription
+ * )) before or use
+ * rosidl_runtime_c__type_description__TypeDescription__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeDescription__init(rosidl_runtime_c__type_description__TypeDescription * msg);
+
+/// Finalize msg/TypeDescription message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeDescription__fini(rosidl_runtime_c__type_description__TypeDescription * msg);
+
+/// Create msg/TypeDescription message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * rosidl_runtime_c__type_description__TypeDescription__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__TypeDescription *
+rosidl_runtime_c__type_description__TypeDescription__create();
+
+/// Destroy msg/TypeDescription message.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__TypeDescription__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeDescription__destroy(rosidl_runtime_c__type_description__TypeDescription * msg);
+
+/// Check for msg/TypeDescription message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeDescription__are_equal(const rosidl_runtime_c__type_description__TypeDescription * lhs, const rosidl_runtime_c__type_description__TypeDescription * rhs);
+
+/// Copy a msg/TypeDescription message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeDescription__copy(
+  const rosidl_runtime_c__type_description__TypeDescription * input,
+  rosidl_runtime_c__type_description__TypeDescription * output);
+
+/// Initialize array of msg/TypeDescription messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * rosidl_runtime_c__type_description__TypeDescription__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeDescription__Sequence__init(rosidl_runtime_c__type_description__TypeDescription__Sequence * array, size_t size);
+
+/// Finalize array of msg/TypeDescription messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__TypeDescription__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeDescription__Sequence__fini(rosidl_runtime_c__type_description__TypeDescription__Sequence * array);
+
+/// Create array of msg/TypeDescription messages.
+/**
+ * It allocates the memory for the array and calls
+ * rosidl_runtime_c__type_description__TypeDescription__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__TypeDescription__Sequence *
+rosidl_runtime_c__type_description__TypeDescription__Sequence__create(size_t size);
+
+/// Destroy array of msg/TypeDescription messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__TypeDescription__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeDescription__Sequence__destroy(rosidl_runtime_c__type_description__TypeDescription__Sequence * array);
+
+/// Check for msg/TypeDescription message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeDescription__Sequence__are_equal(const rosidl_runtime_c__type_description__TypeDescription__Sequence * lhs, const rosidl_runtime_c__type_description__TypeDescription__Sequence * rhs);
+
+/// Copy an array of msg/TypeDescription messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeDescription__Sequence__copy(
+  const rosidl_runtime_c__type_description__TypeDescription__Sequence * input,
+  rosidl_runtime_c__type_description__TypeDescription__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_DESCRIPTION__FUNCTIONS_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_description__struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_description__struct.h
@@ -1,0 +1,62 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_DESCRIPTION__STRUCT_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_DESCRIPTION__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/type_hash.h"
+
+
+// Type Hash for interface
+static const rosidl_type_hash_t rosidl_runtime_c__type_description__TypeDescription__TYPE_HASH = {1, {
+    0x73, 0x9f, 0x25, 0x08, 0xc9, 0xfa, 0x3a, 0x6f,
+    0x33, 0x09, 0x13, 0xff, 0x5b, 0x9d, 0x25, 0xfb,
+    0x74, 0x15, 0x9a, 0x07, 0x7d, 0xa7, 0x1e, 0x10,
+    0x87, 0xf5, 0x1a, 0x60, 0xc1, 0x2a, 0x08, 0x0b,
+  }};
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'type_description'
+// Member 'referenced_type_descriptions'
+#include "rosidl_runtime_c/type_description/individual_type_description__struct.h"
+
+/// Struct defined in msg/TypeDescription in the package type_description_interfaces.
+/**
+  * Represents a complete type description, including the type itself as well as the types it references.
+ */
+typedef struct rosidl_runtime_c__type_description__TypeDescription
+{
+  /// Description of the type.
+  rosidl_runtime_c__type_description__IndividualTypeDescription type_description;
+  /// Descriptions of all referenced types, recursively.
+  rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence referenced_type_descriptions;
+} rosidl_runtime_c__type_description__TypeDescription;
+
+// Struct for a sequence of rosidl_runtime_c__type_description__TypeDescription.
+typedef struct rosidl_runtime_c__type_description__TypeDescription__Sequence
+{
+  rosidl_runtime_c__type_description__TypeDescription * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_runtime_c__type_description__TypeDescription__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_DESCRIPTION__STRUCT_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_source__functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_source__functions.h
@@ -1,0 +1,177 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/TypeSource.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_SOURCE__FUNCTIONS_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_SOURCE__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_runtime_c/type_description/type_source__struct.h"
+
+/// Initialize msg/TypeSource message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * rosidl_runtime_c__type_description__TypeSource
+ * )) before or use
+ * rosidl_runtime_c__type_description__TypeSource__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeSource__init(rosidl_runtime_c__type_description__TypeSource * msg);
+
+/// Finalize msg/TypeSource message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeSource__fini(rosidl_runtime_c__type_description__TypeSource * msg);
+
+/// Create msg/TypeSource message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * rosidl_runtime_c__type_description__TypeSource__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__TypeSource *
+rosidl_runtime_c__type_description__TypeSource__create();
+
+/// Destroy msg/TypeSource message.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__TypeSource__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeSource__destroy(rosidl_runtime_c__type_description__TypeSource * msg);
+
+/// Check for msg/TypeSource message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeSource__are_equal(const rosidl_runtime_c__type_description__TypeSource * lhs, const rosidl_runtime_c__type_description__TypeSource * rhs);
+
+/// Copy a msg/TypeSource message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeSource__copy(
+  const rosidl_runtime_c__type_description__TypeSource * input,
+  rosidl_runtime_c__type_description__TypeSource * output);
+
+/// Initialize array of msg/TypeSource messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * rosidl_runtime_c__type_description__TypeSource__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeSource__Sequence__init(rosidl_runtime_c__type_description__TypeSource__Sequence * array, size_t size);
+
+/// Finalize array of msg/TypeSource messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__TypeSource__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeSource__Sequence__fini(rosidl_runtime_c__type_description__TypeSource__Sequence * array);
+
+/// Create array of msg/TypeSource messages.
+/**
+ * It allocates the memory for the array and calls
+ * rosidl_runtime_c__type_description__TypeSource__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+rosidl_runtime_c__type_description__TypeSource__Sequence *
+rosidl_runtime_c__type_description__TypeSource__Sequence__create(size_t size);
+
+/// Destroy array of msg/TypeSource messages.
+/**
+ * It calls
+ * rosidl_runtime_c__type_description__TypeSource__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+void
+rosidl_runtime_c__type_description__TypeSource__Sequence__destroy(rosidl_runtime_c__type_description__TypeSource__Sequence * array);
+
+/// Check for msg/TypeSource message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeSource__Sequence__are_equal(const rosidl_runtime_c__type_description__TypeSource__Sequence * lhs, const rosidl_runtime_c__type_description__TypeSource__Sequence * rhs);
+
+/// Copy an array of msg/TypeSource messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_runtime_c__type_description__TypeSource__Sequence__copy(
+  const rosidl_runtime_c__type_description__TypeSource__Sequence * input,
+  rosidl_runtime_c__type_description__TypeSource__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_SOURCE__FUNCTIONS_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_source__struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/type_description/type_source__struct.h
@@ -1,0 +1,67 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/TypeSource.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_SOURCE__STRUCT_H_
+#define ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_SOURCE__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/type_hash.h"
+
+
+// Type Hash for interface
+static const rosidl_type_hash_t rosidl_runtime_c__type_description__TypeSource__TYPE_HASH = {1, {
+    0xfa, 0xea, 0xec, 0x75, 0x96, 0xc0, 0x4e, 0xcf,
+    0x5b, 0x6e, 0x99, 0xad, 0x22, 0x5e, 0x4c, 0x7c,
+    0xbb, 0x99, 0x7a, 0xd5, 0x43, 0x5f, 0x79, 0x35,
+    0x26, 0xfb, 0x39, 0x84, 0xd0, 0x11, 0xaa, 0xe5,
+  }};
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'type_name'
+// Member 'encoding'
+// Member 'raw_file_contents'
+#include "rosidl_runtime_c/string.h"
+
+/// Struct defined in msg/TypeSource in the package type_description_interfaces.
+/**
+  * Represents the original source of a ROS 2 interface definition.
+ */
+typedef struct rosidl_runtime_c__type_description__TypeSource
+{
+  /// ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format.
+  rosidl_runtime_c__String type_name;
+  /// The type of the original source file, typically matching the file extension.
+  /// Well-known encodings: "idl", "msg", "srv", "action", "dynamic".
+  rosidl_runtime_c__String encoding;
+  /// Dumped contents of the interface definition source file.
+  /// If this was a type created programmatically (encoding "dynamic"), this field will be empty.
+  rosidl_runtime_c__String raw_file_contents;
+} rosidl_runtime_c__type_description__TypeSource;
+
+// Struct for a sequence of rosidl_runtime_c__type_description__TypeSource.
+typedef struct rosidl_runtime_c__type_description__TypeSource__Sequence
+{
+  rosidl_runtime_c__type_description__TypeSource * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_runtime_c__type_description__TypeSource__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__TYPE_SOURCE__STRUCT_H_

--- a/rosidl_runtime_c/src/type_description/field__functions.c
+++ b/rosidl_runtime_c/src/type_description/field__functions.c
@@ -1,0 +1,293 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+#include "rosidl_runtime_c/type_description/field__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `name`
+// Member `default_value`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `type`
+#include "rosidl_runtime_c/type_description/field_type__functions.h"
+
+bool
+rosidl_runtime_c__type_description__Field__init(rosidl_runtime_c__type_description__Field * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__init(&msg->name)) {
+    rosidl_runtime_c__type_description__Field__fini(msg);
+    return false;
+  }
+  // type
+  if (!rosidl_runtime_c__type_description__FieldType__init(&msg->type)) {
+    rosidl_runtime_c__type_description__Field__fini(msg);
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__init(&msg->default_value)) {
+    rosidl_runtime_c__type_description__Field__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__Field__fini(rosidl_runtime_c__type_description__Field * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // name
+  rosidl_runtime_c__String__fini(&msg->name);
+  // type
+  rosidl_runtime_c__type_description__FieldType__fini(&msg->type);
+  // default_value
+  rosidl_runtime_c__String__fini(&msg->default_value);
+}
+
+bool
+rosidl_runtime_c__type_description__Field__are_equal(const rosidl_runtime_c__type_description__Field * lhs, const rosidl_runtime_c__type_description__Field * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->name), &(rhs->name)))
+  {
+    return false;
+  }
+  // type
+  if (!rosidl_runtime_c__type_description__FieldType__are_equal(
+      &(lhs->type), &(rhs->type)))
+  {
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->default_value), &(rhs->default_value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__Field__copy(
+  const rosidl_runtime_c__type_description__Field * input,
+  rosidl_runtime_c__type_description__Field * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->name), &(output->name)))
+  {
+    return false;
+  }
+  // type
+  if (!rosidl_runtime_c__type_description__FieldType__copy(
+      &(input->type), &(output->type)))
+  {
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__copy(
+      &(input->default_value), &(output->default_value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+rosidl_runtime_c__type_description__Field *
+rosidl_runtime_c__type_description__Field__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__Field * msg = (rosidl_runtime_c__type_description__Field *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__Field), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(rosidl_runtime_c__type_description__Field));
+  bool success = rosidl_runtime_c__type_description__Field__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+rosidl_runtime_c__type_description__Field__destroy(rosidl_runtime_c__type_description__Field * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    rosidl_runtime_c__type_description__Field__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+rosidl_runtime_c__type_description__Field__Sequence__init(rosidl_runtime_c__type_description__Field__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__Field * data = NULL;
+
+  if (size) {
+    data = (rosidl_runtime_c__type_description__Field *)allocator.zero_allocate(size, sizeof(rosidl_runtime_c__type_description__Field), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = rosidl_runtime_c__type_description__Field__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        rosidl_runtime_c__type_description__Field__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__Field__Sequence__fini(rosidl_runtime_c__type_description__Field__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      rosidl_runtime_c__type_description__Field__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+rosidl_runtime_c__type_description__Field__Sequence *
+rosidl_runtime_c__type_description__Field__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__Field__Sequence * array = (rosidl_runtime_c__type_description__Field__Sequence *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__Field__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = rosidl_runtime_c__type_description__Field__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+rosidl_runtime_c__type_description__Field__Sequence__destroy(rosidl_runtime_c__type_description__Field__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    rosidl_runtime_c__type_description__Field__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+rosidl_runtime_c__type_description__Field__Sequence__are_equal(const rosidl_runtime_c__type_description__Field__Sequence * lhs, const rosidl_runtime_c__type_description__Field__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!rosidl_runtime_c__type_description__Field__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__Field__Sequence__copy(
+  const rosidl_runtime_c__type_description__Field__Sequence * input,
+  rosidl_runtime_c__type_description__Field__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(rosidl_runtime_c__type_description__Field);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rosidl_runtime_c__type_description__Field * data =
+      (rosidl_runtime_c__type_description__Field *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!rosidl_runtime_c__type_description__Field__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          rosidl_runtime_c__type_description__Field__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!rosidl_runtime_c__type_description__Field__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rosidl_runtime_c/src/type_description/field_type__functions.c
+++ b/rosidl_runtime_c/src/type_description/field_type__functions.c
@@ -1,0 +1,277 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+#include "rosidl_runtime_c/type_description/field_type__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `nested_type_name`
+#include "rosidl_runtime_c/string_functions.h"
+
+bool
+rosidl_runtime_c__type_description__FieldType__init(rosidl_runtime_c__type_description__FieldType * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_id
+  msg->type_id = 0;
+  // capacity
+  // string_capacity
+  // nested_type_name
+  if (!rosidl_runtime_c__String__init(&msg->nested_type_name)) {
+    rosidl_runtime_c__type_description__FieldType__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__FieldType__fini(rosidl_runtime_c__type_description__FieldType * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_id
+  // capacity
+  // string_capacity
+  // nested_type_name
+  rosidl_runtime_c__String__fini(&msg->nested_type_name);
+}
+
+bool
+rosidl_runtime_c__type_description__FieldType__are_equal(const rosidl_runtime_c__type_description__FieldType * lhs, const rosidl_runtime_c__type_description__FieldType * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_id
+  if (lhs->type_id != rhs->type_id) {
+    return false;
+  }
+  // capacity
+  if (lhs->capacity != rhs->capacity) {
+    return false;
+  }
+  // string_capacity
+  if (lhs->string_capacity != rhs->string_capacity) {
+    return false;
+  }
+  // nested_type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->nested_type_name), &(rhs->nested_type_name)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__FieldType__copy(
+  const rosidl_runtime_c__type_description__FieldType * input,
+  rosidl_runtime_c__type_description__FieldType * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_id
+  output->type_id = input->type_id;
+  // capacity
+  output->capacity = input->capacity;
+  // string_capacity
+  output->string_capacity = input->string_capacity;
+  // nested_type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->nested_type_name), &(output->nested_type_name)))
+  {
+    return false;
+  }
+  return true;
+}
+
+rosidl_runtime_c__type_description__FieldType *
+rosidl_runtime_c__type_description__FieldType__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__FieldType * msg = (rosidl_runtime_c__type_description__FieldType *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__FieldType), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(rosidl_runtime_c__type_description__FieldType));
+  bool success = rosidl_runtime_c__type_description__FieldType__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+rosidl_runtime_c__type_description__FieldType__destroy(rosidl_runtime_c__type_description__FieldType * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    rosidl_runtime_c__type_description__FieldType__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+rosidl_runtime_c__type_description__FieldType__Sequence__init(rosidl_runtime_c__type_description__FieldType__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__FieldType * data = NULL;
+
+  if (size) {
+    data = (rosidl_runtime_c__type_description__FieldType *)allocator.zero_allocate(size, sizeof(rosidl_runtime_c__type_description__FieldType), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = rosidl_runtime_c__type_description__FieldType__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        rosidl_runtime_c__type_description__FieldType__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__FieldType__Sequence__fini(rosidl_runtime_c__type_description__FieldType__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      rosidl_runtime_c__type_description__FieldType__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+rosidl_runtime_c__type_description__FieldType__Sequence *
+rosidl_runtime_c__type_description__FieldType__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__FieldType__Sequence * array = (rosidl_runtime_c__type_description__FieldType__Sequence *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__FieldType__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = rosidl_runtime_c__type_description__FieldType__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+rosidl_runtime_c__type_description__FieldType__Sequence__destroy(rosidl_runtime_c__type_description__FieldType__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    rosidl_runtime_c__type_description__FieldType__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+rosidl_runtime_c__type_description__FieldType__Sequence__are_equal(const rosidl_runtime_c__type_description__FieldType__Sequence * lhs, const rosidl_runtime_c__type_description__FieldType__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!rosidl_runtime_c__type_description__FieldType__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__FieldType__Sequence__copy(
+  const rosidl_runtime_c__type_description__FieldType__Sequence * input,
+  rosidl_runtime_c__type_description__FieldType__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(rosidl_runtime_c__type_description__FieldType);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rosidl_runtime_c__type_description__FieldType * data =
+      (rosidl_runtime_c__type_description__FieldType *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!rosidl_runtime_c__type_description__FieldType__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          rosidl_runtime_c__type_description__FieldType__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!rosidl_runtime_c__type_description__FieldType__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rosidl_runtime_c/src/type_description/individual_type_description__functions.c
+++ b/rosidl_runtime_c/src/type_description/individual_type_description__functions.c
@@ -1,0 +1,273 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+#include "rosidl_runtime_c/type_description/individual_type_description__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_name`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `fields`
+#include "rosidl_runtime_c/type_description/field__functions.h"
+
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__init(rosidl_runtime_c__type_description__IndividualTypeDescription * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__init(&msg->type_name)) {
+    rosidl_runtime_c__type_description__IndividualTypeDescription__fini(msg);
+    return false;
+  }
+  // fields
+  if (!rosidl_runtime_c__type_description__Field__Sequence__init(&msg->fields, 0)) {
+    rosidl_runtime_c__type_description__IndividualTypeDescription__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__fini(rosidl_runtime_c__type_description__IndividualTypeDescription * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_name
+  rosidl_runtime_c__String__fini(&msg->type_name);
+  // fields
+  rosidl_runtime_c__type_description__Field__Sequence__fini(&msg->fields);
+}
+
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__are_equal(const rosidl_runtime_c__type_description__IndividualTypeDescription * lhs, const rosidl_runtime_c__type_description__IndividualTypeDescription * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->type_name), &(rhs->type_name)))
+  {
+    return false;
+  }
+  // fields
+  if (!rosidl_runtime_c__type_description__Field__Sequence__are_equal(
+      &(lhs->fields), &(rhs->fields)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__copy(
+  const rosidl_runtime_c__type_description__IndividualTypeDescription * input,
+  rosidl_runtime_c__type_description__IndividualTypeDescription * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->type_name), &(output->type_name)))
+  {
+    return false;
+  }
+  // fields
+  if (!rosidl_runtime_c__type_description__Field__Sequence__copy(
+      &(input->fields), &(output->fields)))
+  {
+    return false;
+  }
+  return true;
+}
+
+rosidl_runtime_c__type_description__IndividualTypeDescription *
+rosidl_runtime_c__type_description__IndividualTypeDescription__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__IndividualTypeDescription * msg = (rosidl_runtime_c__type_description__IndividualTypeDescription *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__IndividualTypeDescription), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(rosidl_runtime_c__type_description__IndividualTypeDescription));
+  bool success = rosidl_runtime_c__type_description__IndividualTypeDescription__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__destroy(rosidl_runtime_c__type_description__IndividualTypeDescription * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    rosidl_runtime_c__type_description__IndividualTypeDescription__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__init(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__IndividualTypeDescription * data = NULL;
+
+  if (size) {
+    data = (rosidl_runtime_c__type_description__IndividualTypeDescription *)allocator.zero_allocate(size, sizeof(rosidl_runtime_c__type_description__IndividualTypeDescription), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = rosidl_runtime_c__type_description__IndividualTypeDescription__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        rosidl_runtime_c__type_description__IndividualTypeDescription__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__fini(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      rosidl_runtime_c__type_description__IndividualTypeDescription__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence *
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array = (rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__destroy(rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__are_equal(const rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * lhs, const rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!rosidl_runtime_c__type_description__IndividualTypeDescription__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__copy(
+  const rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * input,
+  rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(rosidl_runtime_c__type_description__IndividualTypeDescription);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rosidl_runtime_c__type_description__IndividualTypeDescription * data =
+      (rosidl_runtime_c__type_description__IndividualTypeDescription *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!rosidl_runtime_c__type_description__IndividualTypeDescription__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          rosidl_runtime_c__type_description__IndividualTypeDescription__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!rosidl_runtime_c__type_description__IndividualTypeDescription__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rosidl_runtime_c/src/type_description/key_value__functions.c
+++ b/rosidl_runtime_c/src/type_description/key_value__functions.c
@@ -1,0 +1,272 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/KeyValue.idl
+// generated code does not contain a copyright notice
+#include "rosidl_runtime_c/type_description/key_value__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `key`
+// Member `value`
+#include "rosidl_runtime_c/string_functions.h"
+
+bool
+rosidl_runtime_c__type_description__KeyValue__init(rosidl_runtime_c__type_description__KeyValue * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // key
+  if (!rosidl_runtime_c__String__init(&msg->key)) {
+    rosidl_runtime_c__type_description__KeyValue__fini(msg);
+    return false;
+  }
+  // value
+  if (!rosidl_runtime_c__String__init(&msg->value)) {
+    rosidl_runtime_c__type_description__KeyValue__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__KeyValue__fini(rosidl_runtime_c__type_description__KeyValue * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // key
+  rosidl_runtime_c__String__fini(&msg->key);
+  // value
+  rosidl_runtime_c__String__fini(&msg->value);
+}
+
+bool
+rosidl_runtime_c__type_description__KeyValue__are_equal(const rosidl_runtime_c__type_description__KeyValue * lhs, const rosidl_runtime_c__type_description__KeyValue * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // key
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->key), &(rhs->key)))
+  {
+    return false;
+  }
+  // value
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->value), &(rhs->value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__KeyValue__copy(
+  const rosidl_runtime_c__type_description__KeyValue * input,
+  rosidl_runtime_c__type_description__KeyValue * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // key
+  if (!rosidl_runtime_c__String__copy(
+      &(input->key), &(output->key)))
+  {
+    return false;
+  }
+  // value
+  if (!rosidl_runtime_c__String__copy(
+      &(input->value), &(output->value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+rosidl_runtime_c__type_description__KeyValue *
+rosidl_runtime_c__type_description__KeyValue__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__KeyValue * msg = (rosidl_runtime_c__type_description__KeyValue *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__KeyValue), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(rosidl_runtime_c__type_description__KeyValue));
+  bool success = rosidl_runtime_c__type_description__KeyValue__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+rosidl_runtime_c__type_description__KeyValue__destroy(rosidl_runtime_c__type_description__KeyValue * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    rosidl_runtime_c__type_description__KeyValue__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+rosidl_runtime_c__type_description__KeyValue__Sequence__init(rosidl_runtime_c__type_description__KeyValue__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__KeyValue * data = NULL;
+
+  if (size) {
+    data = (rosidl_runtime_c__type_description__KeyValue *)allocator.zero_allocate(size, sizeof(rosidl_runtime_c__type_description__KeyValue), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = rosidl_runtime_c__type_description__KeyValue__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        rosidl_runtime_c__type_description__KeyValue__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__KeyValue__Sequence__fini(rosidl_runtime_c__type_description__KeyValue__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      rosidl_runtime_c__type_description__KeyValue__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+rosidl_runtime_c__type_description__KeyValue__Sequence *
+rosidl_runtime_c__type_description__KeyValue__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__KeyValue__Sequence * array = (rosidl_runtime_c__type_description__KeyValue__Sequence *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__KeyValue__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = rosidl_runtime_c__type_description__KeyValue__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+rosidl_runtime_c__type_description__KeyValue__Sequence__destroy(rosidl_runtime_c__type_description__KeyValue__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    rosidl_runtime_c__type_description__KeyValue__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+rosidl_runtime_c__type_description__KeyValue__Sequence__are_equal(const rosidl_runtime_c__type_description__KeyValue__Sequence * lhs, const rosidl_runtime_c__type_description__KeyValue__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!rosidl_runtime_c__type_description__KeyValue__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__KeyValue__Sequence__copy(
+  const rosidl_runtime_c__type_description__KeyValue__Sequence * input,
+  rosidl_runtime_c__type_description__KeyValue__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(rosidl_runtime_c__type_description__KeyValue);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rosidl_runtime_c__type_description__KeyValue * data =
+      (rosidl_runtime_c__type_description__KeyValue *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!rosidl_runtime_c__type_description__KeyValue__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          rosidl_runtime_c__type_description__KeyValue__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!rosidl_runtime_c__type_description__KeyValue__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rosidl_runtime_c/src/type_description/type_description__functions.c
+++ b/rosidl_runtime_c/src/type_description/type_description__functions.c
@@ -1,0 +1,272 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+#include "rosidl_runtime_c/type_description/type_description__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_description`
+// Member `referenced_type_descriptions`
+#include "rosidl_runtime_c/type_description/individual_type_description__functions.h"
+
+bool
+rosidl_runtime_c__type_description__TypeDescription__init(rosidl_runtime_c__type_description__TypeDescription * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_description
+  if (!rosidl_runtime_c__type_description__IndividualTypeDescription__init(&msg->type_description)) {
+    rosidl_runtime_c__type_description__TypeDescription__fini(msg);
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__init(&msg->referenced_type_descriptions, 0)) {
+    rosidl_runtime_c__type_description__TypeDescription__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__TypeDescription__fini(rosidl_runtime_c__type_description__TypeDescription * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_description
+  rosidl_runtime_c__type_description__IndividualTypeDescription__fini(&msg->type_description);
+  // referenced_type_descriptions
+  rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__fini(&msg->referenced_type_descriptions);
+}
+
+bool
+rosidl_runtime_c__type_description__TypeDescription__are_equal(const rosidl_runtime_c__type_description__TypeDescription * lhs, const rosidl_runtime_c__type_description__TypeDescription * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_description
+  if (!rosidl_runtime_c__type_description__IndividualTypeDescription__are_equal(
+      &(lhs->type_description), &(rhs->type_description)))
+  {
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__are_equal(
+      &(lhs->referenced_type_descriptions), &(rhs->referenced_type_descriptions)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__TypeDescription__copy(
+  const rosidl_runtime_c__type_description__TypeDescription * input,
+  rosidl_runtime_c__type_description__TypeDescription * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_description
+  if (!rosidl_runtime_c__type_description__IndividualTypeDescription__copy(
+      &(input->type_description), &(output->type_description)))
+  {
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!rosidl_runtime_c__type_description__IndividualTypeDescription__Sequence__copy(
+      &(input->referenced_type_descriptions), &(output->referenced_type_descriptions)))
+  {
+    return false;
+  }
+  return true;
+}
+
+rosidl_runtime_c__type_description__TypeDescription *
+rosidl_runtime_c__type_description__TypeDescription__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__TypeDescription * msg = (rosidl_runtime_c__type_description__TypeDescription *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__TypeDescription), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(rosidl_runtime_c__type_description__TypeDescription));
+  bool success = rosidl_runtime_c__type_description__TypeDescription__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+rosidl_runtime_c__type_description__TypeDescription__destroy(rosidl_runtime_c__type_description__TypeDescription * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    rosidl_runtime_c__type_description__TypeDescription__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+rosidl_runtime_c__type_description__TypeDescription__Sequence__init(rosidl_runtime_c__type_description__TypeDescription__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__TypeDescription * data = NULL;
+
+  if (size) {
+    data = (rosidl_runtime_c__type_description__TypeDescription *)allocator.zero_allocate(size, sizeof(rosidl_runtime_c__type_description__TypeDescription), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = rosidl_runtime_c__type_description__TypeDescription__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        rosidl_runtime_c__type_description__TypeDescription__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__TypeDescription__Sequence__fini(rosidl_runtime_c__type_description__TypeDescription__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      rosidl_runtime_c__type_description__TypeDescription__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+rosidl_runtime_c__type_description__TypeDescription__Sequence *
+rosidl_runtime_c__type_description__TypeDescription__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__TypeDescription__Sequence * array = (rosidl_runtime_c__type_description__TypeDescription__Sequence *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__TypeDescription__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = rosidl_runtime_c__type_description__TypeDescription__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+rosidl_runtime_c__type_description__TypeDescription__Sequence__destroy(rosidl_runtime_c__type_description__TypeDescription__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    rosidl_runtime_c__type_description__TypeDescription__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+rosidl_runtime_c__type_description__TypeDescription__Sequence__are_equal(const rosidl_runtime_c__type_description__TypeDescription__Sequence * lhs, const rosidl_runtime_c__type_description__TypeDescription__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!rosidl_runtime_c__type_description__TypeDescription__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__TypeDescription__Sequence__copy(
+  const rosidl_runtime_c__type_description__TypeDescription__Sequence * input,
+  rosidl_runtime_c__type_description__TypeDescription__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(rosidl_runtime_c__type_description__TypeDescription);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rosidl_runtime_c__type_description__TypeDescription * data =
+      (rosidl_runtime_c__type_description__TypeDescription *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!rosidl_runtime_c__type_description__TypeDescription__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          rosidl_runtime_c__type_description__TypeDescription__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!rosidl_runtime_c__type_description__TypeDescription__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rosidl_runtime_c/src/type_description/type_source__functions.c
+++ b/rosidl_runtime_c/src/type_description/type_source__functions.c
@@ -1,0 +1,292 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/TypeSource.idl
+// generated code does not contain a copyright notice
+#include "rosidl_runtime_c/type_description/type_source__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_name`
+// Member `encoding`
+// Member `raw_file_contents`
+#include "rosidl_runtime_c/string_functions.h"
+
+bool
+rosidl_runtime_c__type_description__TypeSource__init(rosidl_runtime_c__type_description__TypeSource * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__init(&msg->type_name)) {
+    rosidl_runtime_c__type_description__TypeSource__fini(msg);
+    return false;
+  }
+  // encoding
+  if (!rosidl_runtime_c__String__init(&msg->encoding)) {
+    rosidl_runtime_c__type_description__TypeSource__fini(msg);
+    return false;
+  }
+  // raw_file_contents
+  if (!rosidl_runtime_c__String__init(&msg->raw_file_contents)) {
+    rosidl_runtime_c__type_description__TypeSource__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__TypeSource__fini(rosidl_runtime_c__type_description__TypeSource * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_name
+  rosidl_runtime_c__String__fini(&msg->type_name);
+  // encoding
+  rosidl_runtime_c__String__fini(&msg->encoding);
+  // raw_file_contents
+  rosidl_runtime_c__String__fini(&msg->raw_file_contents);
+}
+
+bool
+rosidl_runtime_c__type_description__TypeSource__are_equal(const rosidl_runtime_c__type_description__TypeSource * lhs, const rosidl_runtime_c__type_description__TypeSource * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->type_name), &(rhs->type_name)))
+  {
+    return false;
+  }
+  // encoding
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->encoding), &(rhs->encoding)))
+  {
+    return false;
+  }
+  // raw_file_contents
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->raw_file_contents), &(rhs->raw_file_contents)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__TypeSource__copy(
+  const rosidl_runtime_c__type_description__TypeSource * input,
+  rosidl_runtime_c__type_description__TypeSource * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->type_name), &(output->type_name)))
+  {
+    return false;
+  }
+  // encoding
+  if (!rosidl_runtime_c__String__copy(
+      &(input->encoding), &(output->encoding)))
+  {
+    return false;
+  }
+  // raw_file_contents
+  if (!rosidl_runtime_c__String__copy(
+      &(input->raw_file_contents), &(output->raw_file_contents)))
+  {
+    return false;
+  }
+  return true;
+}
+
+rosidl_runtime_c__type_description__TypeSource *
+rosidl_runtime_c__type_description__TypeSource__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__TypeSource * msg = (rosidl_runtime_c__type_description__TypeSource *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__TypeSource), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(rosidl_runtime_c__type_description__TypeSource));
+  bool success = rosidl_runtime_c__type_description__TypeSource__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+rosidl_runtime_c__type_description__TypeSource__destroy(rosidl_runtime_c__type_description__TypeSource * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    rosidl_runtime_c__type_description__TypeSource__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+rosidl_runtime_c__type_description__TypeSource__Sequence__init(rosidl_runtime_c__type_description__TypeSource__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__TypeSource * data = NULL;
+
+  if (size) {
+    data = (rosidl_runtime_c__type_description__TypeSource *)allocator.zero_allocate(size, sizeof(rosidl_runtime_c__type_description__TypeSource), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = rosidl_runtime_c__type_description__TypeSource__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        rosidl_runtime_c__type_description__TypeSource__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_runtime_c__type_description__TypeSource__Sequence__fini(rosidl_runtime_c__type_description__TypeSource__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      rosidl_runtime_c__type_description__TypeSource__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+rosidl_runtime_c__type_description__TypeSource__Sequence *
+rosidl_runtime_c__type_description__TypeSource__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rosidl_runtime_c__type_description__TypeSource__Sequence * array = (rosidl_runtime_c__type_description__TypeSource__Sequence *)allocator.allocate(sizeof(rosidl_runtime_c__type_description__TypeSource__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = rosidl_runtime_c__type_description__TypeSource__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+rosidl_runtime_c__type_description__TypeSource__Sequence__destroy(rosidl_runtime_c__type_description__TypeSource__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    rosidl_runtime_c__type_description__TypeSource__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+rosidl_runtime_c__type_description__TypeSource__Sequence__are_equal(const rosidl_runtime_c__type_description__TypeSource__Sequence * lhs, const rosidl_runtime_c__type_description__TypeSource__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!rosidl_runtime_c__type_description__TypeSource__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+rosidl_runtime_c__type_description__TypeSource__Sequence__copy(
+  const rosidl_runtime_c__type_description__TypeSource__Sequence * input,
+  rosidl_runtime_c__type_description__TypeSource__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(rosidl_runtime_c__type_description__TypeSource);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rosidl_runtime_c__type_description__TypeSource * data =
+      (rosidl_runtime_c__type_description__TypeSource *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!rosidl_runtime_c__type_description__TypeSource__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          rosidl_runtime_c__type_description__TypeSource__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!rosidl_runtime_c__type_description__TypeSource__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/rosidl_runtime_cpp/CMakeLists.txt
+++ b/rosidl_runtime_cpp/CMakeLists.txt
@@ -34,7 +34,31 @@ if(BUILD_TESTING)
   get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS
     performance_test_fixture::performance_test_fixture INTERFACE_INCLUDE_DIRECTORIES)
 
+  file(GLOB type_description_includes "include/rosidl_runtime_cpp/type_description/*.hpp")
+
+  set(AMENT_LINT_AUTO_FILE_EXCLUDE ${type_description_includes})
   ament_lint_auto_find_test_dependencies()
+
+  # Run specific linters on copied generated code
+  if(ament_cmake_cppcheck_FOUND)
+    ament_cppcheck(
+      TESTNAME "cppcheck_copied_type_description_interfaces"
+      ${type_description_includes})
+  endif()
+  if(ament_cmake_cpplint_FOUND)
+    ament_cpplint(
+      TESTNAME "cpplint_copied_type_description_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ${type_description_includes})
+  endif()
+  if(ament_cmake_uncrustify_FOUND)
+    ament_uncrustify(
+      TESTNAME "uncrustify_copied_type_description_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 0
+      ${type_description_includes})
+  endif()
 
   find_package(ament_cmake_gtest REQUIRED)
 

--- a/rosidl_runtime_cpp/docs/FEATURES.md
+++ b/rosidl_runtime_cpp/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # rosidl_runtime_cpp Features
 
-## Typesupport function handler  
+## Typesupport function handler
 
 `rosidl_runtime_cpp` provides several templated function declarations for getting the type support handler.
 They are meant to be defined in each rosidl definition's C++ generated code.
@@ -25,3 +25,16 @@ These type traits are useful for providing compile-time checks of rosidl C++ typ
 
 Provided in `bounded_vector.hpp` is an implementation of a std::vector like container class, that has a bounded capacity.
 This class is utilized by rosidl types that declare a bounded sequence.
+
+## Type Description Interface Structs
+
+A copy of the output of `rosidl_generator_cpp` for `type_description_interfaces` messages.
+
+Provides base runtime representations of the descriptions of interface types in C++.
+These can be used in code generation to embed descriptions of types, and can be used for programmatic creation of dynamic types.
+The types are renamed so that they do not overlap with `type_description_interfaces` - and can be used in their code generation so that even those messages are self-describing.
+
+Note that end users will typically fetch and use the `type_description_interfaces::msg::TypeDescription` and its members instead of the `rosidl_runtime_cpp` types.
+Functions will be provided in `rclcpp` that convert between `rosidl_runtime_cpp::type_description` and `type_description_interfaces::msg` types.
+
+See `rosidl/scripts/copy_type_descripiton_generated_sources.bash` for usage and details of how sources are copied/updated, and what modifications are made.

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field__struct.hpp
@@ -1,0 +1,176 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__FIELD__STRUCT_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__FIELD__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+// Include directives for member types
+// Member 'type'
+#include "rosidl_runtime_cpp/type_description/field_type__struct.hpp"
+
+#ifndef _WIN32
+# define DEPRECATED__rosidl_runtime_cpp__type_description__Field __attribute__((deprecated))
+#else
+# define DEPRECATED__rosidl_runtime_cpp__type_description__Field __declspec(deprecated)
+#endif
+
+namespace rosidl_runtime_cpp
+{
+
+namespace type_description
+{
+
+// message struct
+template<class ContainerAllocator>
+struct Field_
+{
+  using Type = Field_<ContainerAllocator>;
+
+  constexpr static const rosidl_type_hash_t TYPE_HASH = {1, {
+      0xc0, 0xb0, 0x13, 0x79, 0xcd, 0x42, 0x26, 0x28,
+      0x12, 0x85, 0xcc, 0xaf, 0x6b, 0xe4, 0x66, 0x53,
+      0x96, 0x8f, 0x85, 0x5f, 0x7c, 0x5e, 0x41, 0x61,
+      0x4f, 0xf5, 0xd7, 0xa8, 0x54, 0xef, 0xef, 0x7c,
+    }};
+
+  explicit Field_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type(_init)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->name = "";
+      this->default_value = "";
+    }
+  }
+
+  explicit Field_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : name(_alloc),
+    type(_alloc, _init),
+    default_value(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->name = "";
+      this->default_value = "";
+    }
+  }
+
+  // field types and members
+  using _name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _name_type name;
+  using _type_type =
+    rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>;
+  _type_type type;
+  using _default_value_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _default_value_type default_value;
+
+  // setters for named parameter idiom
+  Type & set__name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->name = _arg;
+    return *this;
+  }
+  Type & set__type(
+    const rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> & _arg)
+  {
+    this->type = _arg;
+    return *this;
+  }
+  Type & set__default_value(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->default_value = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    rosidl_runtime_cpp::type_description::Field_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const rosidl_runtime_cpp::type_description::Field_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__Field
+    std::shared_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__Field
+    std::shared_ptr<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const Field_ & other) const
+  {
+    if (this->name != other.name) {
+      return false;
+    }
+    if (this->type != other.type) {
+      return false;
+    }
+    if (this->default_value != other.default_value) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const Field_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct Field_
+
+// alias to use template instance with default allocator
+using Field =
+  rosidl_runtime_cpp::type_description::Field_<std::allocator<void>>;
+
+template<class ContainerAllocator>
+constexpr const rosidl_type_hash_t Field_<ContainerAllocator>::TYPE_HASH;
+
+// constant definitions
+
+}  // namespace type_description
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__FIELD__STRUCT_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field_type__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field_type__struct.hpp
@@ -1,0 +1,559 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__FIELD_TYPE__STRUCT_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__FIELD_TYPE__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+#ifndef _WIN32
+# define DEPRECATED__rosidl_runtime_cpp__type_description__FieldType __attribute__((deprecated))
+#else
+# define DEPRECATED__rosidl_runtime_cpp__type_description__FieldType __declspec(deprecated)
+#endif
+
+namespace rosidl_runtime_cpp
+{
+
+namespace type_description
+{
+
+// message struct
+template<class ContainerAllocator>
+struct FieldType_
+{
+  using Type = FieldType_<ContainerAllocator>;
+
+  constexpr static const rosidl_type_hash_t TYPE_HASH = {1, {
+      0xa7, 0x0b, 0x6d, 0xd9, 0x19, 0x64, 0x5a, 0x03,
+      0xa3, 0x58, 0x6f, 0x7f, 0x82, 0x1d, 0xef, 0xbc,
+      0x88, 0x6e, 0xa3, 0xe5, 0x31, 0xa1, 0xd9, 0x5c,
+      0xc0, 0xf3, 0x80, 0xa3, 0x97, 0x3c, 0xca, 0xa6,
+    }};
+
+  explicit FieldType_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
+    {
+      this->type_id = 0;
+    } else if (rosidl_runtime_cpp::MessageInitialization::ZERO == _init) {
+      this->type_id = 0;
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+  }
+
+  explicit FieldType_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : nested_type_name(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
+    {
+      this->type_id = 0;
+    } else if (rosidl_runtime_cpp::MessageInitialization::ZERO == _init) {
+      this->type_id = 0;
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+  }
+
+  // field types and members
+  using _type_id_type =
+    uint8_t;
+  _type_id_type type_id;
+  using _capacity_type =
+    uint64_t;
+  _capacity_type capacity;
+  using _string_capacity_type =
+    uint64_t;
+  _string_capacity_type string_capacity;
+  using _nested_type_name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _nested_type_name_type nested_type_name;
+
+  // setters for named parameter idiom
+  Type & set__type_id(
+    const uint8_t & _arg)
+  {
+    this->type_id = _arg;
+    return *this;
+  }
+  Type & set__capacity(
+    const uint64_t & _arg)
+  {
+    this->capacity = _arg;
+    return *this;
+  }
+  Type & set__string_capacity(
+    const uint64_t & _arg)
+  {
+    this->string_capacity = _arg;
+    return *this;
+  }
+  Type & set__nested_type_name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->nested_type_name = _arg;
+    return *this;
+  }
+
+  // constant declarations
+  static constexpr uint8_t FIELD_TYPE_NOT_SET =
+    0u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE =
+    1u;
+  static constexpr uint8_t FIELD_TYPE_INT8 =
+    2u;
+  static constexpr uint8_t FIELD_TYPE_UINT8 =
+    3u;
+  static constexpr uint8_t FIELD_TYPE_INT16 =
+    4u;
+  static constexpr uint8_t FIELD_TYPE_UINT16 =
+    5u;
+  static constexpr uint8_t FIELD_TYPE_INT32 =
+    6u;
+  static constexpr uint8_t FIELD_TYPE_UINT32 =
+    7u;
+  static constexpr uint8_t FIELD_TYPE_INT64 =
+    8u;
+  static constexpr uint8_t FIELD_TYPE_UINT64 =
+    9u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT =
+    10u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE =
+    11u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE =
+    12u;
+  static constexpr uint8_t FIELD_TYPE_CHAR =
+    13u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR =
+    14u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN =
+    15u;
+  static constexpr uint8_t FIELD_TYPE_BYTE =
+    16u;
+  static constexpr uint8_t FIELD_TYPE_STRING =
+    17u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING =
+    18u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING =
+    19u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING =
+    20u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING =
+    21u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING =
+    22u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE_ARRAY =
+    49u;
+  static constexpr uint8_t FIELD_TYPE_INT8_ARRAY =
+    50u;
+  static constexpr uint8_t FIELD_TYPE_UINT8_ARRAY =
+    51u;
+  static constexpr uint8_t FIELD_TYPE_INT16_ARRAY =
+    52u;
+  static constexpr uint8_t FIELD_TYPE_UINT16_ARRAY =
+    53u;
+  static constexpr uint8_t FIELD_TYPE_INT32_ARRAY =
+    54u;
+  static constexpr uint8_t FIELD_TYPE_UINT32_ARRAY =
+    55u;
+  static constexpr uint8_t FIELD_TYPE_INT64_ARRAY =
+    56u;
+  static constexpr uint8_t FIELD_TYPE_UINT64_ARRAY =
+    57u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT_ARRAY =
+    58u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE_ARRAY =
+    59u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE_ARRAY =
+    60u;
+  static constexpr uint8_t FIELD_TYPE_CHAR_ARRAY =
+    61u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR_ARRAY =
+    62u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN_ARRAY =
+    63u;
+  static constexpr uint8_t FIELD_TYPE_BYTE_ARRAY =
+    64u;
+  static constexpr uint8_t FIELD_TYPE_STRING_ARRAY =
+    65u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING_ARRAY =
+    66u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING_ARRAY =
+    67u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING_ARRAY =
+    68u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING_ARRAY =
+    69u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING_ARRAY =
+    70u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE =
+    97u;
+  static constexpr uint8_t FIELD_TYPE_INT8_BOUNDED_SEQUENCE =
+    98u;
+  static constexpr uint8_t FIELD_TYPE_UINT8_BOUNDED_SEQUENCE =
+    99u;
+  static constexpr uint8_t FIELD_TYPE_INT16_BOUNDED_SEQUENCE =
+    100u;
+  static constexpr uint8_t FIELD_TYPE_UINT16_BOUNDED_SEQUENCE =
+    101u;
+  static constexpr uint8_t FIELD_TYPE_INT32_BOUNDED_SEQUENCE =
+    102u;
+  static constexpr uint8_t FIELD_TYPE_UINT32_BOUNDED_SEQUENCE =
+    103u;
+  static constexpr uint8_t FIELD_TYPE_INT64_BOUNDED_SEQUENCE =
+    104u;
+  static constexpr uint8_t FIELD_TYPE_UINT64_BOUNDED_SEQUENCE =
+    105u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE =
+    106u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE =
+    107u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE =
+    108u;
+  static constexpr uint8_t FIELD_TYPE_CHAR_BOUNDED_SEQUENCE =
+    109u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE =
+    110u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE =
+    111u;
+  static constexpr uint8_t FIELD_TYPE_BYTE_BOUNDED_SEQUENCE =
+    112u;
+  static constexpr uint8_t FIELD_TYPE_STRING_BOUNDED_SEQUENCE =
+    113u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE =
+    114u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE =
+    115u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE =
+    116u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE =
+    117u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE =
+    118u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE =
+    145u;
+  static constexpr uint8_t FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE =
+    146u;
+  static constexpr uint8_t FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE =
+    147u;
+  static constexpr uint8_t FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE =
+    148u;
+  static constexpr uint8_t FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE =
+    149u;
+  static constexpr uint8_t FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE =
+    150u;
+  static constexpr uint8_t FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE =
+    151u;
+  static constexpr uint8_t FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE =
+    152u;
+  static constexpr uint8_t FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE =
+    153u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE =
+    154u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE =
+    155u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE =
+    156u;
+  static constexpr uint8_t FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE =
+    157u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE =
+    158u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE =
+    159u;
+  static constexpr uint8_t FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE =
+    160u;
+  static constexpr uint8_t FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE =
+    161u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE =
+    162u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE =
+    163u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE =
+    164u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE =
+    165u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE =
+    166u;
+
+  // pointer types
+  using RawPtr =
+    rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__FieldType
+    std::shared_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__FieldType
+    std::shared_ptr<rosidl_runtime_cpp::type_description::FieldType_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const FieldType_ & other) const
+  {
+    if (this->type_id != other.type_id) {
+      return false;
+    }
+    if (this->capacity != other.capacity) {
+      return false;
+    }
+    if (this->string_capacity != other.string_capacity) {
+      return false;
+    }
+    if (this->nested_type_name != other.nested_type_name) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const FieldType_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct FieldType_
+
+// alias to use template instance with default allocator
+using FieldType =
+  rosidl_runtime_cpp::type_description::FieldType_<std::allocator<void>>;
+
+template<class ContainerAllocator>
+constexpr const rosidl_type_hash_t FieldType_<ContainerAllocator>::TYPE_HASH;
+
+// constant definitions
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NOT_SET;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE;
+
+}  // namespace type_description
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__FIELD_TYPE__STRUCT_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/individual_type_description__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/individual_type_description__struct.hpp
@@ -1,0 +1,159 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+// Include directives for member types
+// Member 'fields'
+#include "rosidl_runtime_cpp/type_description/field__struct.hpp"
+
+#ifndef _WIN32
+# define DEPRECATED__rosidl_runtime_cpp__type_description__IndividualTypeDescription __attribute__((deprecated))
+#else
+# define DEPRECATED__rosidl_runtime_cpp__type_description__IndividualTypeDescription __declspec(deprecated)
+#endif
+
+namespace rosidl_runtime_cpp
+{
+
+namespace type_description
+{
+
+// message struct
+template<class ContainerAllocator>
+struct IndividualTypeDescription_
+{
+  using Type = IndividualTypeDescription_<ContainerAllocator>;
+
+  constexpr static const rosidl_type_hash_t TYPE_HASH = {1, {
+      0x55, 0xc8, 0x27, 0xd8, 0x6c, 0x3c, 0x14, 0x1b,
+      0xdd, 0x31, 0x8f, 0xe6, 0xc2, 0x2e, 0x11, 0x19,
+      0x0e, 0x4d, 0x3b, 0x37, 0xc8, 0xf4, 0xf9, 0x75,
+      0x1a, 0x08, 0x4a, 0xa0, 0x5c, 0xe9, 0x65, 0x60,
+    }};
+
+  explicit IndividualTypeDescription_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->type_name = "";
+    }
+  }
+
+  explicit IndividualTypeDescription_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_name(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->type_name = "";
+    }
+  }
+
+  // field types and members
+  using _type_name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _type_name_type type_name;
+  using _fields_type =
+    std::vector<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>>;
+  _fields_type fields;
+
+  // setters for named parameter idiom
+  Type & set__type_name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->type_name = _arg;
+    return *this;
+  }
+  Type & set__fields(
+    const std::vector<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<rosidl_runtime_cpp::type_description::Field_<ContainerAllocator>>> & _arg)
+  {
+    this->fields = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__IndividualTypeDescription
+    std::shared_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__IndividualTypeDescription
+    std::shared_ptr<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const IndividualTypeDescription_ & other) const
+  {
+    if (this->type_name != other.type_name) {
+      return false;
+    }
+    if (this->fields != other.fields) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const IndividualTypeDescription_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct IndividualTypeDescription_
+
+// alias to use template instance with default allocator
+using IndividualTypeDescription =
+  rosidl_runtime_cpp::type_description::IndividualTypeDescription_<std::allocator<void>>;
+
+template<class ContainerAllocator>
+constexpr const rosidl_type_hash_t IndividualTypeDescription_<ContainerAllocator>::TYPE_HASH;
+
+// constant definitions
+
+}  // namespace type_description
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/key_value__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/key_value__struct.hpp
@@ -1,0 +1,158 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/KeyValue.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__KEY_VALUE__STRUCT_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__KEY_VALUE__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+#ifndef _WIN32
+# define DEPRECATED__rosidl_runtime_cpp__type_description__KeyValue __attribute__((deprecated))
+#else
+# define DEPRECATED__rosidl_runtime_cpp__type_description__KeyValue __declspec(deprecated)
+#endif
+
+namespace rosidl_runtime_cpp
+{
+
+namespace type_description
+{
+
+// message struct
+template<class ContainerAllocator>
+struct KeyValue_
+{
+  using Type = KeyValue_<ContainerAllocator>;
+
+  constexpr static const rosidl_type_hash_t TYPE_HASH = {1, {
+      0x27, 0x4f, 0xe5, 0x6b, 0xf1, 0x4f, 0x33, 0xc7,
+      0x51, 0x2e, 0x34, 0xc6, 0x46, 0xa3, 0x75, 0x79,
+      0xee, 0x36, 0x77, 0x9f, 0x74, 0x5f, 0x04, 0x9a,
+      0x97, 0x60, 0x76, 0x3e, 0x81, 0x7f, 0x0c, 0x42,
+    }};
+
+  explicit KeyValue_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->key = "";
+      this->value = "";
+    }
+  }
+
+  explicit KeyValue_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : key(_alloc),
+    value(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->key = "";
+      this->value = "";
+    }
+  }
+
+  // field types and members
+  using _key_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _key_type key;
+  using _value_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _value_type value;
+
+  // setters for named parameter idiom
+  Type & set__key(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->key = _arg;
+    return *this;
+  }
+  Type & set__value(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->value = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__KeyValue
+    std::shared_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__KeyValue
+    std::shared_ptr<rosidl_runtime_cpp::type_description::KeyValue_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const KeyValue_ & other) const
+  {
+    if (this->key != other.key) {
+      return false;
+    }
+    if (this->value != other.value) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const KeyValue_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct KeyValue_
+
+// alias to use template instance with default allocator
+using KeyValue =
+  rosidl_runtime_cpp::type_description::KeyValue_<std::allocator<void>>;
+
+template<class ContainerAllocator>
+constexpr const rosidl_type_hash_t KeyValue_<ContainerAllocator>::TYPE_HASH;
+
+// constant definitions
+
+}  // namespace type_description
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__KEY_VALUE__STRUCT_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_description__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_description__struct.hpp
@@ -1,0 +1,153 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__TYPE_DESCRIPTION__STRUCT_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__TYPE_DESCRIPTION__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+// Include directives for member types
+// Member 'type_description'
+// Member 'referenced_type_descriptions'
+#include "rosidl_runtime_cpp/type_description/individual_type_description__struct.hpp"
+
+#ifndef _WIN32
+# define DEPRECATED__rosidl_runtime_cpp__type_description__TypeDescription __attribute__((deprecated))
+#else
+# define DEPRECATED__rosidl_runtime_cpp__type_description__TypeDescription __declspec(deprecated)
+#endif
+
+namespace rosidl_runtime_cpp
+{
+
+namespace type_description
+{
+
+// message struct
+template<class ContainerAllocator>
+struct TypeDescription_
+{
+  using Type = TypeDescription_<ContainerAllocator>;
+
+  constexpr static const rosidl_type_hash_t TYPE_HASH = {1, {
+      0x73, 0x9f, 0x25, 0x08, 0xc9, 0xfa, 0x3a, 0x6f,
+      0x33, 0x09, 0x13, 0xff, 0x5b, 0x9d, 0x25, 0xfb,
+      0x74, 0x15, 0x9a, 0x07, 0x7d, 0xa7, 0x1e, 0x10,
+      0x87, 0xf5, 0x1a, 0x60, 0xc1, 0x2a, 0x08, 0x0b,
+    }};
+
+  explicit TypeDescription_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_description(_init)
+  {
+    (void)_init;
+  }
+
+  explicit TypeDescription_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_description(_alloc, _init)
+  {
+    (void)_init;
+  }
+
+  // field types and members
+  using _type_description_type =
+    rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>;
+  _type_description_type type_description;
+  using _referenced_type_descriptions_type =
+    std::vector<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>>;
+  _referenced_type_descriptions_type referenced_type_descriptions;
+
+  // setters for named parameter idiom
+  Type & set__type_description(
+    const rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator> & _arg)
+  {
+    this->type_description = _arg;
+    return *this;
+  }
+  Type & set__referenced_type_descriptions(
+    const std::vector<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<rosidl_runtime_cpp::type_description::IndividualTypeDescription_<ContainerAllocator>>> & _arg)
+  {
+    this->referenced_type_descriptions = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__TypeDescription
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__TypeDescription
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeDescription_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const TypeDescription_ & other) const
+  {
+    if (this->type_description != other.type_description) {
+      return false;
+    }
+    if (this->referenced_type_descriptions != other.referenced_type_descriptions) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const TypeDescription_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct TypeDescription_
+
+// alias to use template instance with default allocator
+using TypeDescription =
+  rosidl_runtime_cpp::type_description::TypeDescription_<std::allocator<void>>;
+
+template<class ContainerAllocator>
+constexpr const rosidl_type_hash_t TypeDescription_<ContainerAllocator>::TYPE_HASH;
+
+// constant definitions
+
+}  // namespace type_description
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__TYPE_DESCRIPTION__STRUCT_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_source__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_source__struct.hpp
@@ -1,0 +1,173 @@
+// DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/TypeSource.idl
+// generated code does not contain a copyright notice
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__TYPE_SOURCE__STRUCT_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__TYPE_SOURCE__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+#ifndef _WIN32
+# define DEPRECATED__rosidl_runtime_cpp__type_description__TypeSource __attribute__((deprecated))
+#else
+# define DEPRECATED__rosidl_runtime_cpp__type_description__TypeSource __declspec(deprecated)
+#endif
+
+namespace rosidl_runtime_cpp
+{
+
+namespace type_description
+{
+
+// message struct
+template<class ContainerAllocator>
+struct TypeSource_
+{
+  using Type = TypeSource_<ContainerAllocator>;
+
+  constexpr static const rosidl_type_hash_t TYPE_HASH = {1, {
+      0xfa, 0xea, 0xec, 0x75, 0x96, 0xc0, 0x4e, 0xcf,
+      0x5b, 0x6e, 0x99, 0xad, 0x22, 0x5e, 0x4c, 0x7c,
+      0xbb, 0x99, 0x7a, 0xd5, 0x43, 0x5f, 0x79, 0x35,
+      0x26, 0xfb, 0x39, 0x84, 0xd0, 0x11, 0xaa, 0xe5,
+    }};
+
+  explicit TypeSource_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->type_name = "";
+      this->encoding = "";
+      this->raw_file_contents = "";
+    }
+  }
+
+  explicit TypeSource_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_name(_alloc),
+    encoding(_alloc),
+    raw_file_contents(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->type_name = "";
+      this->encoding = "";
+      this->raw_file_contents = "";
+    }
+  }
+
+  // field types and members
+  using _type_name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _type_name_type type_name;
+  using _encoding_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _encoding_type encoding;
+  using _raw_file_contents_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _raw_file_contents_type raw_file_contents;
+
+  // setters for named parameter idiom
+  Type & set__type_name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->type_name = _arg;
+    return *this;
+  }
+  Type & set__encoding(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->encoding = _arg;
+    return *this;
+  }
+  Type & set__raw_file_contents(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->raw_file_contents = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__TypeSource
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__rosidl_runtime_cpp__type_description__TypeSource
+    std::shared_ptr<rosidl_runtime_cpp::type_description::TypeSource_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const TypeSource_ & other) const
+  {
+    if (this->type_name != other.type_name) {
+      return false;
+    }
+    if (this->encoding != other.encoding) {
+      return false;
+    }
+    if (this->raw_file_contents != other.raw_file_contents) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const TypeSource_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct TypeSource_
+
+// alias to use template instance with default allocator
+using TypeSource =
+  rosidl_runtime_cpp::type_description::TypeSource_<std::allocator<void>>;
+
+template<class ContainerAllocator>
+constexpr const rosidl_type_hash_t TypeSource_<ContainerAllocator>::TYPE_HASH;
+
+// constant definitions
+
+}  // namespace type_description
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__TYPE_SOURCE__STRUCT_HPP_

--- a/scripts/copy_type_description_generated_sources.bash
+++ b/scripts/copy_type_description_generated_sources.bash
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Description:
+# Copy the structs defined in type_description_interfaces to rosidl_runtime_c and rosidl_runtime_cpp
+# so that they can be used in code generation to describe interface types
+#
+# Usage:
+# First, `colcon build --packages-up-to type_description_interfaces` from the latest sources.
+# Set the following environment variables (script will fail if unset):
+# BUILD_DIR - path to the build output of `type_description_interfaces`
+# ROSIDL_SRC_DIR - path to the `rosidl` repository, where type description files will be placed
+#
+# Example:
+# BUILD_DIR=build/type_description_interfaces ROSIDL_SRC_DIR=src/ros2/rosidl src/ros2/rosidl/scripts/copy_type_description_generated_sources.bash
+
+C_DETAIL=$BUILD_DIR/rosidl_generator_c/type_description_interfaces/msg/detail/
+C_INCLUDE_DEST=$ROSIDL_SRC_DIR/rosidl_runtime_c/include/rosidl_runtime_c/type_description/
+C_SRC_DEST=$ROSIDL_SRC_DIR/rosidl_runtime_c/src/type_description/
+
+CPP_DETAIL=$BUILD_DIR/rosidl_generator_cpp/type_description_interfaces/msg/detail/
+CPP_INCLUDE_DEST=$ROSIDL_SRC_DIR/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/
+
+# C structs
+mkdir -p $C_INCLUDE_DEST
+rm -f $C_INCLUDE_DEST/*.h
+mkdir -p $C_SRC_DEST
+rm -f $C_SRC_DEST/*.c
+
+cp $C_DETAIL/*__struct.h $C_INCLUDE_DEST/
+cp $C_DETAIL/*__functions.h $C_INCLUDE_DEST/
+cp $C_DETAIL/*__functions.c $C_SRC_DEST/
+
+# add copy notice
+sed -i '1s/^/\/\/ DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash\n/' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+# remove unecessary includes (before doing replacements)
+sed -i '/type_description_interfaces\/msg\/rosidl_generator_c__visibility_control.h/d' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+sed -i '/#include "rosidl_runtime_c\/type_description\/type_description__struct.h/d' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+# include guards
+sed -i -e 's/TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__/ROSIDL_RUNTIME_C__TYPE_DESCRIPTION__/g' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+# visibility macros
+sed -i -e 's/ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces/ROSIDL_GENERATOR_C_PUBLIC/g' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+# namespace prefixes
+sed -i -e 's/type_description_interfaces__msg__/rosidl_runtime_c__type_description__/g' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+# includes
+sed -i -e 's/type_description_interfaces\/msg\/detail/rosidl_runtime_c\/type_description/g' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+# sed -i -e 's/extern const rosidl_runtime_c__type_description__TypeDescription/\/\/ extern const rosidl_runtime_c__type_description__TypeDescription/' $C_INCLUDE_DEST/*.h $C_SRC_DEST/*.c
+
+# C++ structs
+mkdir -p $CPP_INCLUDE_DEST
+rm -f $CPP_INCLUDE_DEST/*.hpp
+
+cp $CPP_DETAIL/*__struct.hpp $CPP_INCLUDE_DEST
+
+pushd $CPP_INCLUDE_DEST
+# add copy notice
+sed -i '1s/^/\/\/ DO NOT EDIT MANUALLY - this copied file managed by copy_type_description_generated_sources.bash\n/' *.hpp
+# include guards
+sed -i -e 's/TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__/ROSIDL_RUNTIME_CPP__TYPE_DESCRIPTION__/g' *.hpp
+# pkg namespace
+sed -i -e 's/namespace type_description_interfaces/namespace rosidl_runtime_cpp/g' *.hpp
+# msg namespace
+sed -i -e 's/namespace msg/namespace type_description/g' *.hpp
+# includes
+sed -i -e 's/type_description_interfaces\/msg\/detail/rosidl_runtime_cpp\/type_description/g' *.hpp
+# type references
+sed -i -e 's/type_description_interfaces::msg::/rosidl_runtime_cpp::type_description::/g' *.hpp
+# macros
+sed -i -e 's/type_description_interfaces__msg__/rosidl_runtime_cpp__type_description__/g' *.hpp
+# sed -i -e 's/static const rosidl_runtime_cpp::type_description::TypeDescription/\/\/ static const rosidl_runtime_cpp::type_description::TypeDescription/' *.hpp
+popd


### PR DESCRIPTION
Depends on ros2/rosidl#729
Staging this PR for visibility against PR-in-review. It will have to be reopened against `ros2` when ros2/rosidl#729 is merged.

Provides usable runtime types for use by dynamic types and codegen for type descriptions.

Provides a script that does the copying and modification in a single invocation - all added headers and sources in this change have not been touched by hand and never should be.

For the reviewer - most importantly see scripts/copy_type_description_generated_sources.bash
